### PR TITLE
Allow labels and annotation field validation

### DIFF
--- a/pkg/cmd/sql-sql.go
+++ b/pkg/cmd/sql-sql.go
@@ -16,6 +16,26 @@ import (
 
 // isValidFieldIdentifier checks if a field name matches the allowed pattern
 func isValidFieldIdentifier(field string) bool {
+	// Check for labels.* pattern
+	if strings.HasPrefix(field, "labels.") {
+		labelKey := field[7:] // Remove "labels." prefix
+		// K8s label keys: alphanumeric, hyphens, underscores, dots
+		// Must start and end with alphanumeric character
+		labelPattern := `^[a-zA-Z0-9]([a-zA-Z0-9\-_.]*[a-zA-Z0-9])?$`
+		match, _ := regexp.MatchString(labelPattern, labelKey)
+		return match
+	}
+
+	// Check for annotations.* pattern
+	if strings.HasPrefix(field, "annotations.") {
+		annotationKey := field[12:] // Remove "annotations." prefix
+		// K8s annotation keys: similar to labels but more flexible
+		// Can contain alphanumeric, hyphens, underscores, dots, and slashes
+		annotationPattern := `^[a-zA-Z0-9]([a-zA-Z0-9\-_./]*[a-zA-Z0-9])?$`
+		match, _ := regexp.MatchString(annotationPattern, annotationKey)
+		return match
+	}
+
 	// Matches patterns like:
 	// - simple: name, first_name, my.field
 	// - array access: items[0], my.array[123]


### PR DESCRIPTION
Fixes: https://github.com/yaacov/kubectl-sql/issues/25

Before:
``` bash
16:30 $ kubectl-sql "select name, status.phase, annotations.security.openshift.io/validated-scc-subject-type as scc from */pods"
Error: invalid field identifier before AS: annotations.security.openshift.io/validated-scc-subject-type
Usage:
  sql <query> [flags] [options]
  sql [command]

Examples:
  # Print client version.
  kubectl sql version
```

After:
```bash
16:29 $ kubectl-sql "select name, status.phase, annotations.security.openshift.io/validated-scc-subject-type as scc from */pods"
KIND: Pod	COUNT: 446
name                                                           	status.phase	scc           	
openshift-apiserver-operator-558c446987-f4h77                  	Running     	serviceaccount	
apiserver-587d568646-bvmbp                                     	Running     	serviceaccount	
apiserver-587d568646-gk8ll                                     	Running     	serviceaccount	
apiserver-587d568646-l774l                                     	Running     	serviceaccount	
authentication-operator-5855f5d9b4-6szrm                       	Running     	serviceaccount	
oauth-openshift-6f5fdcbc8f-ft5bj                               	Running     	serviceaccount	

```